### PR TITLE
Remove deprecated properties

### DIFF
--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -878,11 +878,10 @@ static void _settings_autoshow_menu(GtkWidget *button, dt_iop_module_t *module)
   GtkWidget *popover = darktable.view_manager->guides_popover;
   gtk_popover_set_relative_to(GTK_POPOVER(popover), button);
 
-  g_object_set(G_OBJECT(popover), "transitions-enabled", FALSE, NULL);
-
   dt_guides_update_popover_values();
 
-  gtk_widget_show_all(popover);
+  // use popover_popup for transition and widget_show for not
+  gtk_widget_show(popover);
 }
 
 void dt_guides_init_module_widget(GtkWidget *iopw, dt_iop_module_t *module)

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1776,7 +1776,6 @@ static void _topbar_show_pref_menu(dt_lib_module_t *self, GtkWidget *bt)
 
   // initialize the popover
   d->topbar_popup = gtk_popover_new(bt);
-  g_object_set(G_OBJECT(d->topbar_popup), "transitions-enabled", FALSE, NULL);
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_container_add(GTK_CONTAINER(d->topbar_popup), vbox);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -3204,7 +3204,6 @@ void gui_init(dt_lib_module_t *self)
   renderer = gtk_cell_renderer_toggle_new();
   gtk_tree_view_column_pack_start(col, renderer, TRUE);
   gtk_tree_view_column_set_cell_data_func(col, renderer, _tree_select_show, NULL, NULL);
-  g_object_set(renderer, "indicator-size", 8, NULL);  // too big by default
 
   col = gtk_tree_view_column_new();
   gtk_tree_view_append_column(view, col);
@@ -3317,7 +3316,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_column_pack_start(col, renderer, TRUE);
   gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
   gtk_tree_view_column_set_cell_data_func(col, renderer, _tree_select_show, NULL, NULL);
-  g_object_set(renderer, "indicator-size", 8, NULL);  // too big by default
 
   col = gtk_tree_view_column_new();
   gtk_tree_view_append_column(view, col);

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -405,7 +405,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), d->overlays_button, FALSE, FALSE, 0);
   d->over_popup = gtk_popover_new(d->overlays_button);
   gtk_widget_set_size_request(d->over_popup, 350, -1);
-  g_object_set(G_OBJECT(d->over_popup), "transitions-enabled", FALSE, NULL);
   g_signal_connect(G_OBJECT(d->overlays_button), "clicked", G_CALLBACK(_overlays_show_popup), self);
   // we register size of overlay icon to keep in sync thumbtable overlays
   g_signal_connect(G_OBJECT(d->overlays_button), "size-allocate", G_CALLBACK(_main_icons_register_size), NULL);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1397,8 +1397,9 @@ static void _second_window_quickbutton_clicked(GtkWidget *w, dt_develop_t *dev)
 
 /** toolbar buttons */
 
-static gboolean _toolbar_show_popup(gpointer user_data)
+static gboolean _toolbar_show_popup(gpointer user_data, gboolean transition)
 {
+
   GtkPopover *popover = GTK_POPOVER(user_data);
 
   GtkWidget *button = gtk_popover_get_relative_to(popover);
@@ -1421,7 +1422,15 @@ static gboolean _toolbar_show_popup(gpointer user_data)
   if(darktable.view_manager && GTK_WIDGET(popover) == darktable.view_manager->guides_popover)
     dt_guides_update_popover_values();
 
-  gtk_widget_show_all(GTK_WIDGET(popover));
+  // decide to use transition or not
+  if (transition)
+  {
+    gtk_popover_popup(popover);
+  }
+  else
+  {
+    gtk_widget_show(GTK_WIDGET(popover));
+  }
 
   // cancel glib timeout if invoked by long button press
   return FALSE;
@@ -2217,9 +2226,8 @@ static gboolean _quickbutton_press_release(GtkWidget *button,
   {
     gtk_popover_set_relative_to(GTK_POPOVER(popover), button);
 
-    g_object_set(G_OBJECT(popover), "transitions-enabled", FALSE, NULL);
+    _toolbar_show_popup(popover, FALSE);
 
-    _toolbar_show_popup(popover);
     return TRUE;
   }
   else

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1163,7 +1163,6 @@ void gui_init(dt_view_t *self)
   // and the popup window
   lib->profile_floating_window = gtk_popover_new(profile_button);
 
-  g_object_set(G_OBJECT(lib->profile_floating_window), "transitions-enabled", FALSE, NULL);
   g_signal_connect_swapped(G_OBJECT(profile_button), "button-press-event", G_CALLBACK(gtk_widget_show_all), lib->profile_floating_window);
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);


### PR DESCRIPTION
Both properties are deprecated. I just removed them, or replaced them with other methods. The only thing I see as a result, is the bigger checkbox here on a high definition display. I would say, they now have the right size, like the other checkboxes. I cannot test how this looks on different displays or scales.