### PR TITLE
Remove gtk_widget_set_app_paintable

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -917,7 +917,6 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
                         | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                         | GDK_STRUCTURE_MASK
                         | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
-  gtk_widget_set_app_paintable(table->widget, TRUE);
   gtk_widget_set_can_focus(table->widget, TRUE);
 
   g_signal_connect(G_OBJECT(table->widget), "scroll-event",

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -125,7 +125,6 @@ GtkWidget *dtgtk_thumbnail_btn_new(DTGTKCairoPaintIconFunc paint, gint paintflag
                                                 | GDK_POINTER_MOTION_MASK | GDK_BUTTON_PRESS_MASK
                                                 | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK
                                                 | GDK_ENTER_NOTIFY_MASK | GDK_ALL_EVENTS_MASK);
-  gtk_widget_set_app_paintable(GTK_WIDGET(button), TRUE);
   gtk_widget_set_name(GTK_WIDGET(button), "thumbnail_btn");
   return (GtkWidget *)button;
 }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2423,7 +2423,6 @@ dt_thumbtable_t *dt_thumbtable_new()
                         | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                         | GDK_STRUCTURE_MASK
                         | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK);
-  gtk_widget_set_app_paintable(table->widget, TRUE);
   gtk_widget_set_can_focus(table->widget, TRUE);
 
   // drag and drop : used for reordering, interactions with maps,

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1369,7 +1369,6 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_gui_presets_init();
 
   widget = dt_ui_center(darktable.gui->ui);
-  gtk_widget_set_app_paintable(widget, TRUE);
 
   // TODO: make this work as: libgnomeui testgnome.c
   /*  GtkContainer *box = GTK_CONTAINER(darktable.gui->widgets.plugins_vbox);
@@ -1626,7 +1625,6 @@ static GtkWidget *_init_outer_border(const gint width,
 {
   GtkWidget *widget = gtk_drawing_area_new();
   gtk_widget_set_size_request(widget, width, height);
-  gtk_widget_set_app_paintable(widget, TRUE);
   gtk_widget_set_events(widget,
                         GDK_EXPOSURE_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                         | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_STRUCTURE_MASK
@@ -1786,7 +1784,6 @@ static void _init_main_table(GtkWidget *container)
   gtk_widget_set_size_request(cda, DT_PIXEL_APPLY_DPI(50), DT_PIXEL_APPLY_DPI(200));
   gtk_widget_set_hexpand(ocda, TRUE);
   gtk_widget_set_vexpand(ocda, TRUE);
-  gtk_widget_set_app_paintable(cda, TRUE);
   gtk_widget_set_events(cda,
                         GDK_POINTER_MOTION_MASK | GDK_BUTTON_PRESS_MASK
                         | GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -1034,7 +1034,6 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const dt_imgid_t imgid)
     GtkWidget *da = gtk_drawing_area_new();
     gtk_widget_set_size_request(da, psize, psize);
     gtk_widget_set_halign(da, GTK_ALIGN_CENTER);
-    gtk_widget_set_app_paintable(da, TRUE);
     gtk_box_pack_start(GTK_BOX(ht), da, TRUE, TRUE, 0);
     data.first_draw = TRUE;
     g_signal_connect(G_OBJECT(da), "draw", G_CALLBACK(_preview_draw), &data);

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -154,7 +154,6 @@ void gui_init(dt_lib_module_t *self)
      _("navigation\nclick or drag to position zoomed area in center view"));
 
   /* connect callbacks */
-  gtk_widget_set_app_paintable(thumbnail, TRUE);
   g_signal_connect(G_OBJECT(thumbnail), "draw",
                    G_CALLBACK(_lib_navigation_draw_callback), self);
   g_signal_connect(G_OBJECT(thumbnail), "button-press-event",

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -95,7 +95,6 @@ void gui_init(dt_lib_module_t *self)
 
   /* connect callbacks */
   gtk_widget_set_tooltip_text(drawing, _("set star rating for selected images"));
-  gtk_widget_set_app_paintable(drawing, TRUE);
   g_signal_connect(G_OBJECT(drawing), "draw", G_CALLBACK(_lib_ratings_draw_callback), self);
   g_signal_connect(G_OBJECT(drawing), "button-press-event", G_CALLBACK(_lib_ratings_button_press_callback), self);
   g_signal_connect(G_OBJECT(drawing), "button-release-event", G_CALLBACK(_lib_ratings_button_release_callback),

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3593,7 +3593,6 @@ static void _darkroom_display_second_window(dt_develop_t *dev)
     gtk_widget_set_size_request(dev->preview2.widget, DT_PIXEL_APPLY_DPI_2ND_WND(dev, 50), DT_PIXEL_APPLY_DPI_2ND_WND(dev, 200));
     gtk_widget_set_hexpand(dev->preview2.widget, TRUE);
     gtk_widget_set_vexpand(dev->preview2.widget, TRUE);
-    gtk_widget_set_app_paintable(dev->preview2.widget, TRUE);
 
     gtk_widget_set_events(dev->preview2.widget, GDK_POINTER_MOTION_MASK
                                                          | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK


### PR DESCRIPTION
As part of the migration to gtk4 remove the method gtk_widget_set_app_paintable. The gtk3 documentation says, that most widgets already ignore this setting and it is only helpful if you want to change the background of some widgets.

After testing the change, I can't see any widget background that might have changed. Maybe it has already been changed, or I just missed a change.